### PR TITLE
fixes MIDI learn not working. polyeffects/digit_ui#51

### DIFF
--- a/src/server/ControlBindings.cpp
+++ b/src/server/ControlBindings.cpp
@@ -255,6 +255,8 @@ ControlBindings::start_learn(PortImpl* port)
 	Binding* b = _learn_binding.load();
 	if (!b) {
 		_learn_binding = new Binding();
+        b = _learn_binding.load();
+        b->port = port; // need to specify port here
 	} else {
 		b->port = port;
 	}
@@ -392,7 +394,6 @@ ControlBindings::set_port_value(RunContext& ctx,
 	float min = 0.0f;
 	float max = 1.0f;
 	get_range(ctx, port, &min, &max);
-
 	const float val = control_to_port_value(ctx, port, type, value);
 
 	// TODO: Set port value property so it is saved


### PR DESCRIPTION
I'm not really sure what's going on here and how this ever actually worked. Bindings weren't having a port set if they were a new binding, and where then crashing when accessed in set_port_value, as they were a null pointer.